### PR TITLE
Make Drush extension's version constraint on Drush less restrictive.

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -117,7 +117,7 @@ class Project
                     $composerMap[$top]['name'] = $this->getName();
                 }
                 $composerMap[$top]['type'] = 'drupal-drush';
-                $composerMap[$top]['require']['drush/drush'] = '6.*';
+                $composerMap[$top]['require']['drush/drush'] = '>=6';
             }
         }
 


### PR DESCRIPTION
Drush extensions should be allowed to co-exist with multiple versions of Drush.  See: https://github.com/drupal-composer/drupal-packagist/issues/5

This PR changes the version restriction to allow Drush 6 or later.