### PR TITLE
Fix Version::valid

### DIFF
--- a/spec/Drupal/ParseComposer/VersionSpec.php
+++ b/spec/Drupal/ParseComposer/VersionSpec.php
@@ -29,4 +29,21 @@ class VersionSpec extends ObjectBehavior
         $this->getSemver()->shouldReturn('6.2.16-rc1');
     }
 
+    function it_validates_full_versions() {
+        $this->beConstructedWith('7.x-2.4-beta');
+
+        $this::valid('7.x-2.0')->shouldReturn(TRUE);
+        $this::valid('7.x-2.x-dev')->shouldReturn(TRUE);
+        $this::valid('7.x-2.4-beta3')->shouldReturn(TRUE);
+        $this::valid('6.x-2.16-rc1')->shouldReturn(TRUE);
+
+        /**
+         * Some drupal.org repositories contain invalid tags.
+         * - http://cgit.drupalcode.org/backup_migrate/refs/tags
+         * - http://cgit.drupalcode.org/migrate/refs/tags
+         */
+        $this::valid('7.x-2.x-beta1')->shouldReturn(FALSE);
+        $this::valid('7.x-3.x-alpha')->shouldReturn(FALSE);
+    }
+
 }


### PR DESCRIPTION
The current regex in Version::valid does not work for all version strings. There are some Repos with invalid tags https://github.com/drupal-composer/drupal-packagist/issues/18. We need a proper validate function to remove these tags from our packagist. This cause issues with dist urls because there are multiple tags refere to a single git hash and there is no dist package for invalid tags on drupal.org