### PR TITLE
Correct package URL for projects that had invalid short names fixed

### DIFF
--- a/src/DrupalOrg/DistInformation.php
+++ b/src/DrupalOrg/DistInformation.php
@@ -30,6 +30,9 @@ class DistInformation
      */
     public function __construct($projectName, $refName)
     {
+        // Correct projects that had invalid short names fixed. @see https://www.drupal.org/node/2240255
+        $projectName = str_replace('-', '_', $projectName);
+
         $version = preg_replace('/(\.x)$/', '$1-dev', $refName, -1, $count);
         if ($count == 0) {
             $this->url = sprintf(


### PR DESCRIPTION
As noted in drupal-composer/drupal-packagist#37, dist downloads for projects that were created with an invalid short name that has since been fixed fail with a 404 and fall back to git.  
I wasn't able to find a more relevant location to change the project name (or aware of how it would potentially affect other components like the git URL), so this PR changes the package URLs to always use underscores in file names.

Files created prior to when the fixes were applied on Drupal.org ~1 year ago will still have hyphens in their file names and would start to fail with a 404 instead, but I think this is a reasonable tradeoff to make recent packages work as expected and will likely have little practical impact given that any active project will have had an updated release since the short name fixes were applied.