### PR TITLE
Don't add ~ to exact version constraints

### DIFF
--- a/src/GitDriver.php
+++ b/src/GitDriver.php
@@ -107,11 +107,6 @@ class GitDriver extends BaseDriver implements FileFinderInterface
                 $composer['require'],
                 array_combine($keys, $keys)
             );
-            foreach ($composer['require'] as $name => $constraint) {
-                if (preg_match('/^\d+\.\d+\.\d+$/', $constraint)) {
-                    $composer['require'][$name] = "~$constraint";
-                }
-            }
             $composer += array(
                 'description' => null,
                 'require' => array(),


### PR DESCRIPTION
This reverts the big WTF discussed in #56 and drupal-composer/drupal-packagist#63, and introduced in d7a00788d3dcfd3ce0b2aac55abdb64c47246840.